### PR TITLE
Index by the message-id for spam deletions

### DIFF
--- a/myindex.cc
+++ b/myindex.cc
@@ -188,6 +188,7 @@ int main(int argc, char** argv)
           if ((msgnum > lasthavemsgnum) || regenerate) {
             document * doc = parse_article(msg);
             if (doc != NULL) {
+	      doc->msgid = msgid;
               xapian_add_document(doc, list, year, month, msgnum);
               unflushed_messages++;
             }

--- a/myindex.cc
+++ b/myindex.cc
@@ -188,8 +188,7 @@ int main(int argc, char** argv)
           if ((msgnum > lasthavemsgnum) || regenerate) {
             document * doc = parse_article(msg);
             if (doc != NULL) {
-	      doc->msgid = msgid;
-              xapian_add_document(doc, list, year, month, msgnum);
+              xapian_add_document(doc, msgid, list, year, month, msgnum);
               unflushed_messages++;
             }
           }

--- a/templates/query
+++ b/templates/query
@@ -132,11 +132,12 @@ $NEXT
 $hitlist{<tr><td valign="top">
 ${<IMG SRC="/images/xapian-omega/score-$div{$percentage,10}.png" ALT="$percentage%" HEIGHT=16 WIDTH=32>}
 </td>
-<td><b><a href="$field{url}">$html{$or{$field{subject},(no subject)}}</a></b> 
+$def{URL,$transform{^http://,https://,$field{url}}}
+<td><b><a href="$URL">$html{$or{$field{subject},(no subject)}}</a></b>
  $field{author}<br />
 <small>$highlight{$field{sample},$terms}$if{$field{sample},...}</small><br />
 <p style="text-align: right; float: right; font-size: small; margin: 0pt;">
-<a href="$field{url}">$html{$field{url}}</a>
+<a href="$URL">$html{$URL}</a>
 </p>
 <small>
 $percentage% relevant$. matching:

--- a/tokenizer.h
+++ b/tokenizer.h
@@ -24,6 +24,7 @@ typedef struct {
   std::string author;
   std::string email;
   std::string subject;
+  std::string msgid;
   time_t date;
   char body[MAX_SAVED_BODY_LENGTH];
 } document;

--- a/tokenizer.h
+++ b/tokenizer.h
@@ -24,7 +24,6 @@ typedef struct {
   std::string author;
   std::string email;
   std::string subject;
-  std::string msgid;
   time_t date;
   char body[MAX_SAVED_BODY_LENGTH];
 } document;

--- a/xapianglue.cc
+++ b/xapianglue.cc
@@ -20,6 +20,9 @@ extern "C" {
 
 using namespace std;
 
+// Use for the "XI" terms which index message-ids.
+const unsigned MAX_TERM_LENGTH = 250;
+
 Xapian::WritableDatabase db;
 Xapian::Document * doc = NULL;
 Xapian::TermGenerator indexer;
@@ -87,7 +90,7 @@ xapian_delete_document(std::string & list, int year, int month, int  msgnum)
 }
 
 void
-xapian_add_document(const document *d, std::string & list, int year, int month, int  msgnum)
+xapian_add_document(const document *d, std::string & msgid, std::string & list, int year, int month, int  msgnum)
 {
     if (doc == NULL)
 	merror("xapian_add_document called before xapian_new_document");
@@ -132,12 +135,12 @@ xapian_add_document(const document *d, std::string & list, int year, int month, 
       sprintf(buf, "%04d", year);      
     doc->add_boolean_term((string("XM")+list+"-")+buf);
 
-    if (d->msgid.size() <= MAX_TERM_LENGTH - 2) {
-	doc->add_boolean_term(string("XI") + d->msgid);
+    if (msgid.size() <= MAX_TERM_LENGTH - 2) {
+	doc->add_boolean_term(string("XI") + msgid);
     } else {
 	// Truncate - we verify the full message id before deleting in cases
 	// where it might be truncated.
-	doc->add_boolean_term(string("XI") + d->msgid.substr(0, MAX_TERM_LENGTH - 2));
+	doc->add_boolean_term(string("XI") + msgid.substr(0, MAX_TERM_LENGTH - 2));
     }
 
     struct tm ts;
@@ -191,7 +194,7 @@ xapian_add_document(const document *d, std::string & list, int year, int month, 
     data += '\n';
     data += d->body;
     data += '\n';
-    data += d->msgid;
+    data += msgid;
 
     if (verbose >= 2) printf("data:[%s]\n\n", data.c_str());
     doc->set_data(data);

--- a/xapianglue.cc
+++ b/xapianglue.cc
@@ -131,7 +131,15 @@ xapian_add_document(const document *d, std::string & list, int year, int month, 
     else
       sprintf(buf, "%04d", year);      
     doc->add_boolean_term((string("XM")+list+"-")+buf);
-    
+
+    if (d->msgid.size() <= MAX_TERM_LENGTH - 2) {
+	doc->add_boolean_term(string("XI") + d->msgid);
+    } else {
+	// Truncate - we verify the full message id before deleting in cases
+	// where it might be truncated.
+	doc->add_boolean_term(string("XI") + d->msgid.substr(0, MAX_TERM_LENGTH - 2));
+    }
+
     struct tm ts;
     memset(&ts, 0, sizeof(ts));
     ts.tm_year = year-1900;
@@ -181,8 +189,9 @@ xapian_add_document(const document *d, std::string & list, int year, int month, 
     data += '\n';
     data += d->email;
     data += '\n';
-
     data += d->body;
+    data += '\n';
+    data += d->msgid;
 
     if (verbose >= 2) printf("data:[%s]\n\n", data.c_str());
     doc->set_data(data);

--- a/xapianglue.h
+++ b/xapianglue.h
@@ -13,7 +13,7 @@ extern time_t start_time;
 
 #include <string>
 
-void xapian_add_document(const document *d, std::string & list, int year, int month, int msgnum);
+void xapian_add_document(const document *d, std::string & msgid, std::string & list, int year, int month, int msgnum);
 void xapian_delete_document(std::string & list, int year, int month, int  msgnum);
 void xapian_delete_msgid(std::string & msgid);
 void xapian_set_stemmer(const std::string lang);

--- a/xapianglue.h
+++ b/xapianglue.h
@@ -15,5 +15,6 @@ extern time_t start_time;
 
 void xapian_add_document(const document *d, std::string & list, int year, int month, int msgnum);
 void xapian_delete_document(std::string & list, int year, int month, int  msgnum);
+void xapian_delete_msgid(std::string & msgid);
 void xapian_set_stemmer(const std::string lang);
 long xapian_open_db_for_month(const std::string month, const bool deleteallexisting);


### PR DESCRIPTION
We need this to be able to find the documents to delete efficiently - the map for the message-id lookup gets purged of the message-ids of spam messages, so we can't use that.

Once this is merged, we need to do a full reindex from scratch, which should actually get rid of all reported spam as we check for known spam at index time.  But going forward, we'll have the necessary data to delete newly reported spam (the code for this part needs sorting out still).
