### PR TITLE
Tell gmime to read mbox files

### DIFF
--- a/myindex.cc
+++ b/myindex.cc
@@ -157,7 +157,7 @@ try {
     stream = g_mime_stream_fs_new(fh);
 
     parser = g_mime_parser_new_with_stream(stream);
-    g_mime_parser_set_format(parser, GMIME_FORMAT_MESSAGE);
+    g_mime_parser_set_format(parser, GMIME_FORMAT_MBOX);
     g_mime_parser_set_respect_content_length(parser, TRUE);
     gint64 old_pos = -1;
     while (! g_mime_parser_eos(parser)) {


### PR DESCRIPTION
Since the update to use gmime3 we were telling gmime to read each mbox file as a single message, resulting in only the first file from each mbox being indexed.

Fixes https://bugs.debian.org/1091321